### PR TITLE
Pin PyTorch version to 2.2.2 to resolve import error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ package_dir =
 packages = find:
 python_requires = >=3.8
 install_requires =
-    torch>=1.12
+    torch==2.2.2
     bitsandbytes==0.41.1
     accelerate>=0.27.2
     huggingface-hub>=0.11.1,<1.0.0


### PR DESCRIPTION
Addressing the import error encountered with PyTorch 2.3.0 as detailed in issue #576.  fixes #576